### PR TITLE
allow add middleware after app has started

### DIFF
--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -50,6 +50,7 @@ def check_versions():
 
 def initialize():
     from modules import initialize_util
+    initialize_util.allow_add_middleware_after_start()
     initialize_util.fix_torch_version()
     initialize_util.fix_pytorch_lightning()
     initialize_util.fix_asyncio_event_loop_policy()


### PR DESCRIPTION
this should completely fix "Cannot add middleware after an application has started" which can occur due to a race condition

## Description

* a simple description of what you're trying to accomplish
* a summary of changes in code
* which issues it fixes, if any

## Screenshots/videos:

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

## Summary by Sourcery

Allow dynamic addition of middleware to a running Starlette application by patching add_middleware to reset and lazily rebuild the middleware stack on failure, and integrate this patch into the initialization process

Bug Fixes:
- Fix the "Cannot add middleware after an application has started" runtime error by retrying middleware addition after resetting the stack

Enhancements:
- Monkey-patch Starlette.add_middleware to catch RuntimeError, reset middleware_stack, retry addition, and fallback to direct insertion into user_middleware
- Remove manual middleware_stack resets and on-the-fly middleware stack rebuilds in setup_middleware in favor of the new lazy patch

## Summary by Sourcery

Enable dynamic middleware addition after application startup by patching Starlette.add_middleware to lazily rebuild its stack on failure and updating initialization to apply this patch

Bug Fixes:
- Fix "Cannot add middleware after an application has started" error by resetting and rebuilding the middleware stack on failure

Enhancements:
- Monkey-patch Starlette.add_middleware to catch runtime errors, reset the middleware stack, retry addition, and fall back to direct insertion into user_middleware
- Simplify setup_middleware by removing explicit middleware_stack resets and on-the-fly stack rebuilding