### PR TITLE
fix RestrictedUnpickler

### DIFF
--- a/modules/safe.py
+++ b/modules/safe.py
@@ -37,6 +37,9 @@ class RestrictedUnpickler(pickle.Unpickler):
             if res is not None:
                 return res
 
+        class Empty:
+            pass
+
         if module == 'collections' and name == 'OrderedDict':
             return getattr(collections, name)
         if module == 'torch._utils' and name in ['_rebuild_tensor_v2', '_rebuild_parameter', '_rebuild_device_tensor_from_numpy']:
@@ -51,12 +54,8 @@ class RestrictedUnpickler(pickle.Unpickler):
             return getattr(numpy, name)
         if module == '_codecs' and name == 'encode':
             return encode
-        if module == "pytorch_lightning.callbacks" and name == 'model_checkpoint':
-            import pytorch_lightning.callbacks
-            return pytorch_lightning.callbacks.model_checkpoint
-        if module == "pytorch_lightning.callbacks.model_checkpoint" and name == 'ModelCheckpoint':
-            import pytorch_lightning.callbacks.model_checkpoint
-            return pytorch_lightning.callbacks.model_checkpoint.ModelCheckpoint
+        if module.startswith("pytorch_lightning"):
+            return Empty
         if module == "__builtin__" and name == 'set':
             return set
 


### PR DESCRIPTION
it does no harm to remove the pytorch_lightening dependency

see also https://github.com/comfyanonymous/ComfyUI/commit/735ac4cf81862b21902b312930ebfc92eef63357

## Description

* a simple description of what you're trying to accomplish
* a summary of changes in code
* which issues it fixes, if any

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

## Summary by Sourcery

Stub out pytorch_lightning classes in RestrictedUnpickler to remove the dependency and avoid import errors when unpickling pytorch_lightning objects.

Enhancements:
- Introduce an Empty placeholder class to handle unpickled pytorch_lightning modules.
- Replace specific pytorch_lightning callback imports with a generic stub for any module starting with pytorch_lightning.